### PR TITLE
Fix CD-ROM repository issue in setup script

### DIFF
--- a/setup_home_version.py
+++ b/setup_home_version.py
@@ -32,6 +32,9 @@ def run(cmd, check=True, env=None):
     return rc
 
 def apt_update():
+    # Fix CD-ROM repository issue on Linux Mint/Ubuntu systems
+    print("🔧 Removing CD-ROM repository entries to prevent apt update issues...")
+    run("sudo sed -i '/cdrom:/d' /etc/apt/sources.list", check=False)
     run(["sudo", "-E", "apt-get", "update", "-y"])
 
 def apt_install(packages):


### PR DESCRIPTION
- Add sed command to remove CD-ROM entries from /etc/apt/sources.list
- Prevents apt-get update failures on Linux Mint/Ubuntu systems
- Uses check=False to avoid failure if no CD-ROM entries exist
- Resolves issue where setup fails with 'repository does not have a Release file' error

Tested on Linux Mint 22.1 and resolves the installation blocking issue.